### PR TITLE
Prevent tick crashes after developer login

### DIFF
--- a/shim.cpp
+++ b/shim.cpp
@@ -28,6 +28,12 @@ struct PlatformShim {
     std::atomic<bool> run{false};
     std::thread tick_thread;
     int tick_ms{16};
+    std::mutex tick_mu;
+
+    // retain copies of input strings so EOS can reference them safely
+    std::string s_product_id, s_sandbox_id, s_deployment_id;
+    std::string s_client_id, s_client_secret;
+    std::string s_encryption_key, s_cache_dir;
     ~PlatformShim() {
         stop_tick_thread();
         if (h) {
@@ -35,13 +41,17 @@ struct PlatformShim {
             h = nullptr;
         }
     }
+    void tick_once() {
+        std::lock_guard<std::mutex> lk(tick_mu);
+        if (h) EOS_Platform_Tick(h);
+    }
     void start_tick_thread(int period_ms) {
         if (run.load()) return;
         tick_ms = period_ms > 0 ? period_ms : 16;
         run.store(true);
         tick_thread = std::thread([this]{
             while (run.load()) {
-                if (h) EOS_Platform_Tick(h);
+                tick_once();
                 std::this_thread::sleep_for(std::chrono::milliseconds(tick_ms));
             }
         });
@@ -85,6 +95,12 @@ struct WaitState {
     bool done{false};
     EOS_EResult rc{EOS_UnexpectedError};
     std::string epic_id;
+
+    // owned storage for async EOS_Auth_Login inputs
+    std::string id_s;
+    std::string token_s;
+    EOS_Auth_Credentials creds{};
+    EOS_Auth_LoginOptions opts{};
 };
 
 static EOS_HAuth auth_if(PlatformShim* ps) {
@@ -115,27 +131,38 @@ DLL_EXPORT void* eos_platform_create_basic(const char* product_id,
                                            const char* cache_dir,
                                            int is_server,
                                            int tick_budget_ms) {
+    auto* ps = new PlatformShim();
+
+    // take ownership of all inputs so EOS can safely reference them
+    ps->s_product_id    = product_id    ? product_id    : "";
+    ps->s_sandbox_id    = sandbox_id    ? sandbox_id    : "";
+    ps->s_deployment_id = deployment_id ? deployment_id : "";
+    ps->s_client_id     = client_id     ? client_id     : "";
+    ps->s_client_secret = client_secret ? client_secret : "";
+    ps->s_encryption_key= encryption_key? encryption_key: "";
+    ps->s_cache_dir     = cache_dir     ? cache_dir     : "";
+
     EOS_Platform_ClientCredentials creds{};
     creds.ApiVersion  = EOS_PLATFORM_CLIENTCREDENTIALS_API_LATEST;
-    creds.ClientId    = client_id;
-    creds.ClientSecret= client_secret;
+    creds.ClientId    = ps->s_client_id.empty() ? nullptr : ps->s_client_id.c_str();
+    creds.ClientSecret= ps->s_client_secret.empty() ? nullptr : ps->s_client_secret.c_str();
 
     EOS_Platform_Options opts{};
     opts.ApiVersion = EOS_PLATFORM_OPTIONS_API_LATEST;
-    opts.ProductId  = product_id;
-    opts.SandboxId  = sandbox_id;
-    opts.DeploymentId = deployment_id;
+    opts.ProductId  = ps->s_product_id.empty() ? nullptr : ps->s_product_id.c_str();
+    opts.SandboxId  = ps->s_sandbox_id.empty() ? nullptr : ps->s_sandbox_id.c_str();
+    opts.DeploymentId = ps->s_deployment_id.empty() ? nullptr : ps->s_deployment_id.c_str();
     opts.ClientCredentials = creds;
-    opts.EncryptionKey = (encryption_key && *encryption_key) ? encryption_key : nullptr;
-    opts.CacheDirectory= (cache_dir && *cache_dir) ? cache_dir : nullptr;
+    opts.EncryptionKey = ps->s_encryption_key.empty() ? nullptr : ps->s_encryption_key.c_str();
+    opts.CacheDirectory= ps->s_cache_dir.empty() ? nullptr : ps->s_cache_dir.c_str();
     opts.bIsServer = is_server ? EOS_TRUE : EOS_FALSE;
     opts.TickBudgetInMilliseconds = tick_budget_ms;
 
-    EOS_HPlatform h = EOS_Platform_Create(&opts);
-    if (!h) return nullptr;
-
-    auto* ps = new PlatformShim();
-    ps->h = h;
+    ps->h = EOS_Platform_Create(&opts);
+    if (!ps->h) {
+        delete ps;
+        return nullptr;
+    }
     return reinterpret_cast<void*>(ps);
 }
 
@@ -147,8 +174,8 @@ DLL_EXPORT void eos_platform_release(void* handle) {
 
 DLL_EXPORT void eos_platform_tick(void* handle) {
     auto* ps = reinterpret_cast<PlatformShim*>(handle);
-    if (!ps || !ps->h) return;
-    EOS_Platform_Tick(ps->h);
+    if (!ps) return;
+    ps->tick_once();
 }
 
 DLL_EXPORT int eos_platform_start_tick_thread(void* handle, int tick_period_ms) {
@@ -179,20 +206,21 @@ static EOS_EResult do_login_blocking(PlatformShim* ps,
     EOS_HAuth h = auth_if(ps);
     if (!h) return EOS_InvalidAuth;
 
-    EOS_Auth_Credentials creds{};
-    creds.ApiVersion = EOS_AUTH_CREDENTIALS_API_LATEST;
-    creds.Type = type;
-    creds.Id = id;
-    creds.Token = token;
-
-    EOS_Auth_LoginOptions opts{};
-    opts.ApiVersion = EOS_AUTH_LOGIN_API_LATEST;
-    opts.Credentials = &creds;
-    opts.ScopeFlags = EOS_AS_BasicProfile | EOS_AS_FriendsList;
-    opts.bPersistLogin = persist ? EOS_TRUE : EOS_FALSE;
-
     WaitState st;
-    EOS_Auth_Login(h, &opts, &st,
+    st.id_s    = id    ? id    : "";
+    st.token_s = token ? token : "";
+
+    st.creds.ApiVersion = EOS_AUTH_CREDENTIALS_API_LATEST;
+    st.creds.Type = type;
+    st.creds.Id = st.id_s.empty() ? nullptr : st.id_s.c_str();
+    st.creds.Token = st.token_s.empty() ? nullptr : st.token_s.c_str();
+
+    st.opts.ApiVersion = EOS_AUTH_LOGIN_API_LATEST;
+    st.opts.Credentials = &st.creds;
+    st.opts.ScopeFlags = EOS_AS_BasicProfile | EOS_AS_FriendsList;
+    st.opts.bPersistLogin = persist ? EOS_TRUE : EOS_FALSE;
+
+    EOS_Auth_Login(h, &st.opts, &st,
         [](const EOS_Auth_LoginCallbackInfo* info){
             auto* pst = static_cast<WaitState*>(info->ClientData);
             std::lock_guard<std::mutex> lk(pst->m);
@@ -205,7 +233,7 @@ static EOS_EResult do_login_blocking(PlatformShim* ps,
     std::unique_lock<std::mutex> lk(st.m);
     while (!st.done) {
         lk.unlock();
-        if (ps && ps->h) EOS_Platform_Tick(ps->h);
+        if (ps) ps->tick_once();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         lk.lock();
         if (!st.done) st.cv.wait_for(lk, std::chrono::milliseconds(10));
@@ -289,7 +317,7 @@ DLL_EXPORT int eos_auth_logout(void* handle,
     std::unique_lock<std::mutex> lk(st.m);
     while (!st.done) {
         lk.unlock();
-        if (ps && ps->h) EOS_Platform_Tick(ps->h);
+        if (ps) ps->tick_once();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         lk.lock();
         if (!st.done) st.cv.wait_for(lk, std::chrono::milliseconds(10));
@@ -350,7 +378,7 @@ DLL_EXPORT int eos_auth_query_id_token(void* handle,
     std::unique_lock<std::mutex> lk(st.m);
     while (!st.done) {
         lk.unlock();
-        if (ps && ps->h) EOS_Platform_Tick(ps->h);
+        if (ps) ps->tick_once();
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         lk.lock();
         if (!st.done) st.cv.wait_for(lk, std::chrono::milliseconds(10));


### PR DESCRIPTION
## Summary
- Guard platform ticks with a mutex to avoid concurrent access
- Keep platform option strings alive for the lifetime of the platform handle
- Ensure blocking auth logins tick safely and retain credential buffers
